### PR TITLE
Random build fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,21 @@ Building USD on Windows
 -----------------------
 Note that the windows build is a work in progress, and the 
 branch may not yet be in a buildable state.
+
+Prereqs:
+ 1. Install Python and Pip
+ 1. pip install PySide
+ 1. pip install pyd (unclear if this is necessary or not)
+ 1. Ensure PySide tools (in python/scripts) are visible on %PATH%
+ 1. Install CMake and make sure its on your %PATH%
+ 1. Install NASM, make sure it's on your %PATH% in the working terminal
+ 1. Install 7-Zip, make sure 7z is on your %PATH% in the working terminal
+ 1. Download & unzip win-bison (and win-flex), no need to be on the path
+ 1. Download Qt via the binary installer, default install works at the time of this writing
+ 1. Ensure qmake.exe is on the %PATH% in the working terminal
+
+In a **64-bit VS2015** Developer command prompt:
+
 ```
   mkdir Projects
   cd Projects
@@ -23,13 +38,20 @@ branch may not yet be in a buildable state.
   ..\usd-build-club\prerequisites-vc140-x64\boost.cmd
   ..\usd-build-club\prerequisites-vc140-x64\tbb.cmd
   ..\usd-build-club\prerequisites-vc140-x64\glew.cmd
+  ..\usd-build-club\prerequisites-vc140-x64\glext.cmd
   ..\usd-build-club\prerequisites-vc140-x64\openexr.cmd
   ..\usd-build-club\prerequisites-vc140-x64\OpenSubdiv.cmd
   ..\usd-build-club\prerequisites-vc140-x64\OpenImageIO.cmd
   ..\usd-build-club\configure.cmd
   cd prereq\build\usd
-  cmake --build . --target install --config Release
+  cmake --build . --target install --config Release -- /maxcpucount:16
 ```
+
+Using the install:
+ 1. Add [PATH TO STAGE]\local\bin to %PATH%
+ 1. Add [PATH TO STAGE]\local\lib to %PATH%
+ 1. Add [PATH TO STAGE]\local\lib\python to %PYTHONPATH%
+ 1. Run python> from pxr import Usd
 
 Building USD on OSX
 -------------------

--- a/configure.cmd
+++ b/configure.cmd
@@ -5,7 +5,8 @@ SET builddir=%cd%\local
 if not exist "prereq\build\USD" mkdir prereq\build\USD
 cd prereq\build\USD
 
-cmake ..\..\..\..\USD_win ^
+REM // USE_PTEX=0 because ptex integration is currently broken with the latest version of ptex
+cmake ..\..\..\..\USD ^
       -DPXR_BUILD_MAYA_PLUGIN=0 ^
       -DPXR_BUILD_KATANA_PLUGIN=0 ^
       -DCMAKE_INSTALL_PREFIX="%builddir%" ^
@@ -17,8 +18,9 @@ cmake ..\..\..\..\USD_win ^
       -DOPENEXR_ROOT_DIR="%builddir%" ^
       -DOPENSUBDIV_ROOT_DIR="%builddir%" ^
       -DQT_ROOT_DIR="%builddir%" ^
-      -DPTEX_LOCATION="%builddir%" ^
       -DTBB_ROOT_DIR="%builddir%" ^
       -DBoost_INCLUDE_DIR="%builddir%"/include -DBoost_LIBRARY_DIR="%builddir%"/lib ^
       -DPXR_INSTALL_LOCATION="%builddir%" ^
+      -DPTEX_LOCATION="%builddir%" ^
+      -DUSE_PTEX=0 ^
       -G "Visual Studio 14 2015 Win64"

--- a/prerequisites-vc140-x64/OpenImageIO.cmd
+++ b/prerequisites-vc140-x64/OpenImageIO.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "oiio" ^
@@ -11,6 +14,7 @@ cd ..
 if not exist "build\oiio" mkdir build\oiio
 cd build\oiio
 
+REM -DUSE_PTEX=0 because ptex was recently changed and doesn't work with several projects
 cmake -G "Visual Studio 14 2015 Win64"^
     -DCMAKE_PREFIX_PATH="%current%\local"^
     -DCMAKE_INSTALL_PREFIX="%current%\local" ^
@@ -23,10 +27,11 @@ cmake -G "Visual Studio 14 2015 Win64"^
     -DBoost_LIBRARY_DIR_RELEASE="%current%\local\lib" ^
     -DBoost_LIBRARY_DIR_DEBUG="%current%\local\lib" ^
     -DOCIO_PATH="%current%\local" ^
-    -DPTEX_LOCATION="%current%\local\lib" ^
+    -DPTEX_LOCATION="%current%\local" ^
+    -DUSE_PTEX=0 ^
     ..\..\oiio
 
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:16
 
 rem msbuild oiio.sln /t:Build /p:Configuration=Release /p:Platform=x64
 

--- a/prerequisites-vc140-x64/OpenSubdiv.cmd
+++ b/prerequisites-vc140-x64/OpenSubdiv.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "build\OpenSubdiv" ^
@@ -13,14 +16,35 @@ cd ..
 
 cd build\OpenSubdiv
 
+REM Optional Stuff:
+REM -DCUDA_TOOLKIT_ROOT_DIR=[path to CUDA Toolkit]
+REM -DMAYA_LOCATION=[path to Maya]
+REM ptex is disabled because the OpenSubdiv version detection seems broken
+
 cmake -G "Visual Studio 14 2015 Win64"^
+      -DPTEX_LOCATION=%current%/local/^
+      -DGLEW_LOCATION=%current%/local^
+      -DGLFW_LOCATION=%current%/local^
+      -DTBB_LOCATION=%current%/local^
+      -DNO_EXAMPLES=0^
+      -DNO_TUTORIALS=0^
+      -DNO_REGRESSION=0^
+      -DNO_MAYA=1^
+      -DNO_PTEX=1^
+      -DNO_DOC=1^
+      -DNO_OMP=1^
+      -DNO_TBB=0^
+      -DNO_CUDA=1^
+      -DNO_OPENCL=1^
+      -DNO_OPENGL=0^
+      -DNO_CLEW=0^
       -DCMAKE_PREFIX_PATH="%current%\local"^
       -DGLEW_LOCATION="%current%\local"^
       -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\OpenSubdiv
 
 rem msbuild OpenSubdiv.sln /t:Build /p:Configuration=Release /p:Platform=x64
 echo "Building OpenSubdiv Debug"
-cmake --build . --target install --config Debug
+cmake --build . --target install --config Debug -- /maxcpucount:8
 
 cd ..\..\..\local\lib
 ren osdCPU.lib osdCPU_debug.lib
@@ -28,7 +52,7 @@ ren osdGPU.lib osdGPU_debug.lib
 cd ..\..\prereq\build\OpenSubdiv
 
 echo "Building OpenSubdiv Release"
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:8
 
 cd %current%
 

--- a/prerequisites-vc140-x64/boost.cmd
+++ b/prerequisites-vc140-x64/boost.cmd
@@ -1,3 +1,6 @@
+SET current=%cd%
+
+if not exist "prereq" ^
 mkdir prereq
 cd prereq
 
@@ -8,13 +11,13 @@ cd boost-build-club
 git pull
 cd ..
 
-if not exists "boost.tar.gz" ^
+if not exist "boost.tar.gz" ^
 powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://downloads.sourceforge.net/sourceforge/boost/boost_1_61_0.tar.gz', 'boost.tar.gz')"
 
-if not exists "boost.tar" ^
+if not exist "boost.tar" ^
 7z x boost.tar.gz
 
-if not exists "boost_1_61_0\README.md" ^
+if not exist "boost_1_61_0\README.md" ^
 7z x -ttar boost.tar
 
 xcopy .\boost-build-club\* .\boost_1_61_0\ /s /y

--- a/prerequisites-vc140-x64/double-conversion.cmd
+++ b/prerequisites-vc140-x64/double-conversion.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "double-conversion\CMakeLists.txt" ^
@@ -13,7 +16,7 @@ mkdir build\double-conversion
 
 cd build\double-conversion
 
-cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="%current%" ..\..\double-conversion
+cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="%current%"\local ..\..\double-conversion
 cmake --build . --target install --config Release
 rem msbuild double-conversion.sln /t:Build /p:Configuration=Release /p:Platform=x64
 

--- a/prerequisites-vc140-x64/glew.cmd
+++ b/prerequisites-vc140-x64/glew.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "glew-build-club/README.md" ^
@@ -15,15 +18,27 @@ cd .\prereq\glew-build-club
 if not exist "build_win" mkdir build_win
 cd build_win
 
-cl /c -DSTATIC -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
-lib /out:glew_static.lib glew.obj
-cl /c -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
-link /dll /out:glew.dll glew.obj opengl32.lib
-cl /c -DSTATIC -DGLEW_MX -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
-lib /out:glew_mx_static.lib glew.obj
-cl /c -DGLEW_MX -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
-link /dll /out:glew_mx.dll glew.obj opengl32.lib
+REM
+REM WARNING: You must run the 64-bit developer command prompt for the following.
+REM build to compile correctly.
+REM
+
+REM We are intentionally ONLY building the static library here, as there are
+REM known issues with linking OpenSubdiv and USD with mixed static/dynamic
+REM configurations.
+
+cl /c -DSTATIC -DGLEW_STATIC -I"%current%\local\include" ..\src\glew.c
+lib /out:glew32s.lib glew.obj
+
+REM cl /c -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
+REM link /dll /out:glew.dll glew.obj opengl32.lib
+REM cl /c -DSTATIC -DGLEW_MX -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
+REM lib /out:glew_mx_static.lib glew.obj
+REM cl /c -DGLEW_MX -DGLEW_BUILD -I"%current%\local\include" ..\src\glew.c
+REM link /dll /out:glew_mx.dll glew.obj opengl32.lib
 
 xcopy *.lib "%current%\local\lib\" /s /y
 xcopy *.dll "%current%\local\bin\" /s /y
+
 cd %current%
+

--- a/prerequisites-vc140-x64/glext.cmd
+++ b/prerequisites-vc140-x64/glext.cmd
@@ -1,0 +1,11 @@
+
+set stage=%cd%
+
+if not exist "local/include/GL" ^
+mkdir local/include/GL
+cd local/include/GL
+
+if not exist "glext.h" ^
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.opengl.org/registry/api/GL/glext.h', 'glext.h')"
+
+cd %stage%

--- a/prerequisites-vc140-x64/glfw.cmd
+++ b/prerequisites-vc140-x64/glfw.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "build\glfw" ^
@@ -17,6 +20,6 @@ cmake -G "Visual Studio 14 2015 Win64"^
       -DCMAKE_PREFIX_PATH="%current%\local"^
       -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\glfw
 
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:16
 
 cd %current%

--- a/prerequisites-vc140-x64/jpeg.cmd
+++ b/prerequisites-vc140-x64/jpeg.cmd
@@ -3,7 +3,12 @@ echo http://www.nasm.us/pub/nasm/releasebuilds
 echo nasm must be in the path.
 
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
+
 cd prereq
+
 git clone https://github.com/libjpeg-turbo/libjpeg-turbo.git
 
 if not exist "build\libjpeg-turbo" mkdir build\libjpeg-turbo
@@ -13,7 +18,7 @@ cmake -G "Visual Studio 14 2015 Win64"^
       -DCMAKE_PREFIX_PATH="%current%\local"^
       -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\libjpeg-turbo
 
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:8
 
 rem msbuild libjpeg-turbo.sln /t:Build /p:Configuration=Release /p:Platform=x64
 

--- a/prerequisites-vc140-x64/openexr.cmd
+++ b/prerequisites-vc140-x64/openexr.cmd
@@ -1,13 +1,17 @@
 echo zlib is a prerequisite for OpenEXR
 
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
+
 git clone git://github.com/meshula/openexr.git
 
 if not exist "build\IlmBase" mkdir build\IlmBase
 cd build\IlmBase
 cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\openexr\IlmBase
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:8
 
 rem msbuild ilmBase.sln /t:Build /p:Configuration=Release /p:Platform=x64
 

--- a/prerequisites-vc140-x64/png.cmd
+++ b/prerequisites-vc140-x64/png.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "build\libpng" ^
@@ -17,7 +20,7 @@ cmake -G "Visual Studio 14 2015 Win64"^
       -DCMAKE_PREFIX_PATH="%current%\local"^
       -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\libpng
 
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:8
 
 rem msbuild libpng.sln /t:Build /p:Configuration=Release /p:Platform=x64
 cd %current%

--- a/prerequisites-vc140-x64/ptex.cmd
+++ b/prerequisites-vc140-x64/ptex.cmd
@@ -1,4 +1,8 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
+
 cd prereq
 
 if not exist "ptex\CMakeLists.txt" ^
@@ -19,8 +23,9 @@ cmake -G "Visual Studio 14 2015 Win64" ^
       -DZLIB_LIBRARY="%current%\local\lib\zlib.lib" ^
       ..\..\ptex
 
+rem // This build is not thread-safe, must use maxcpucount:1
 if exist "ptex.sln" ^
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:1
 
 cd ../../..
 

--- a/prerequisites-vc140-x64/tbb.cmd
+++ b/prerequisites-vc140-x64/tbb.cmd
@@ -1,6 +1,8 @@
 
 set SCRIPT_DIR=%~dp0
 
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "tbb.zip" ^

--- a/prerequisites-vc140-x64/tiff.cmd
+++ b/prerequisites-vc140-x64/tiff.cmd
@@ -1,4 +1,7 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
 cd prereq
 
 if not exist "build\libtiff" ^
@@ -17,7 +20,7 @@ cmake -G "Visual Studio 14 2015 Win64"^
       -DCMAKE_PREFIX_PATH="%current%\local"^
       -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\libtiff
 
-cmake --build . --target install --config Release
+cmake --build . --target install --config Release -- /maxcpucount:8
 
 rem msbuild tiff.sln /t:Build /p:Configuration=Release /p:Platform=x64
 cd %current%

--- a/prerequisites-vc140-x64/zlib.cmd
+++ b/prerequisites-vc140-x64/zlib.cmd
@@ -1,4 +1,8 @@
 SET current=%cd%
+
+if not exist "prereq" ^
+mkdir prereq
+
 cd prereq
 
 if not exist "zlib/CMakeLists.txt" ^
@@ -13,10 +17,10 @@ mkdir build\zlib
 
 cd build\zlib
 
-cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="%current%" ..\..\zlib
-cmake --build . --target install --config Release
-rem msbuild zlib.sln /t:Build /p:Configuration=Release /p:Platform=x64
+cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="%current%\local" ..\..\zlib
+cmake --build . --target install --config Release -- /maxcpucount:8 
+
 cd %current%
-rem xcopy .\prereq\zlib\zlib.h .\local\include\ /s /y
-rem xcopy .\prereq\build\zlib\zconf.h .\local\include /s /y
-rem xcopy .\prereq\build\zlib\Release\zlib.* .\local\lib /s /y
+
+rem // xcopy .\inst\zlib\include\* .\local\include\ /s /y
+rem // xcopy .\inst\zlib\lib\* .\local\lib\ /s /y


### PR DESCRIPTION
- Add "glext.h" fetcher
- Multi-thread all the things
- Fix zlib & double-conversion to go into stage/local
- Fix boost (exists -> exist)
- Disable Ptex due to recent version breakage (both oiio and OpenSubdiv)
- Fix Glew build configuration
- Force static Glew linkage
- Use conventional Glew library names (soon to be required by USD cmake)
- Guard against non-existing "prereqs" dir
- Explicitly setup OpenSubdiv flags
