### PR TITLE
Re-enable ptex for OpenSubdiv builds

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,11 +44,10 @@ In a **64-bit VS2015** Developer command prompt:
   ..\usd-build-club\prerequisites-vc140-x64\OpenSubdiv.cmd
   ..\usd-build-club\prerequisites-vc140-x64\OpenImageIO.cmd
   ..\usd-build-club\configure.cmd
-  cd prereq\build\usd
   cmake --build . --target install --config Release -- /maxcpucount:16
 ```
 
-For a debug build (at least currently), two files must be edited in the USD source directory:
+For debug builds (at least currently), OpenSubdiv must be compiled in debug config (edit OpenSubdiv.cmd) and two files must be edited in the USD source directory:
 
 cmake/defaults/msvcdefaults.cmake
   - uncomment add_definitions("/DTBB_USE_DEBUG=1")

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ Prereqs:
  1. Install Python and Pip
  1. pip install PySide
  1. pip install pyd (unclear if this is necessary or not)
+ 1. pip install pyopengl (required for usdview)
  1. Ensure PySide tools (in python/scripts) are visible on %PATH%
  1. Install CMake and make sure its on your %PATH%
  1. Install NASM, make sure it's on your %PATH% in the working terminal
@@ -47,11 +48,21 @@ In a **64-bit VS2015** Developer command prompt:
   cmake --build . --target install --config Release -- /maxcpucount:16
 ```
 
+For a debug build (at least currently), two files must be edited in the USD source directory:
+
+cmake/defaults/msvcdefaults.cmake
+  - uncomment add_definitions("/DTBB_USE_DEBUG=1")
+
+cmake/defaults/Packages.cmake
+  - line 45: set(TBB_USE_DEBUG_BUILD ON)
+
 Using the install:
  1. Add [PATH TO STAGE]\local\bin to %PATH%
  1. Add [PATH TO STAGE]\local\lib to %PATH%
  1. Add [PATH TO STAGE]\local\lib\python to %PYTHONPATH%
- 1. Run python> from pxr import Usd
+
+Test the build:
+ 1. python> from pxr import Usd
 
 Building USD on OSX
 -------------------

--- a/prerequisites-vc140-x64/OpenSubdiv.cmd
+++ b/prerequisites-vc140-x64/OpenSubdiv.cmd
@@ -12,6 +12,8 @@ git clone https://github.com/PixarAnimationStudios/OpenSubdiv.git
 
 cd OpenSubdiv
 git pull
+REM checkout the dev branch, since 3.0.5 ptex detection was broken by changes in ptex changes.
+git checkout dev
 cd ..
 
 cd build\OpenSubdiv
@@ -19,18 +21,17 @@ cd build\OpenSubdiv
 REM Optional Stuff:
 REM -DCUDA_TOOLKIT_ROOT_DIR=[path to CUDA Toolkit]
 REM -DMAYA_LOCATION=[path to Maya]
-REM ptex is disabled because the OpenSubdiv version detection seems broken
 
 cmake -G "Visual Studio 14 2015 Win64"^
       -DPTEX_LOCATION=%current%/local/^
       -DGLEW_LOCATION=%current%/local^
       -DGLFW_LOCATION=%current%/local^
       -DTBB_LOCATION=%current%/local^
-      -DNO_EXAMPLES=0^
-      -DNO_TUTORIALS=0^
-      -DNO_REGRESSION=0^
+      -DNO_EXAMPLES=1^
+      -DNO_TUTORIALS=1^
+      -DNO_REGRESSION=1^
       -DNO_MAYA=1^
-      -DNO_PTEX=1^
+      -DNO_PTEX=0^
       -DNO_DOC=1^
       -DNO_OMP=1^
       -DNO_TBB=0^


### PR DESCRIPTION
Looks like the dev branch of OpenSubdiv has a ptex fix, we can use that until
3.1 releases.

Also disable examples, tutorials and regression in the build. I originally enabled
these because they function to expose linking issues, but they slow compile times
and bloat the output directory.
